### PR TITLE
Use killall since it's available on OpenWRT-Yun

### DIFF
--- a/packages/fcserver/src/fcserver.init
+++ b/packages/fcserver/src/fcserver.init
@@ -14,7 +14,7 @@ start() {
 
 stop() {
 	echo -n "Stopping $DESC: $NAME"
-	pkill -f fcserver
+	killall fcserver
 	echo "."
 }
 


### PR DESCRIPTION
OpenWRT-Yun doesn't have pkill by default
