### PR TITLE
Add libusbx dependency

### DIFF
--- a/packages/fcserver/Makefile
+++ b/packages/fcserver/Makefile
@@ -20,7 +20,7 @@ define Package/fcserver
   CATEGORY:=Utilities
   TITLE:=FadeCandy Server
 	URL:=https://github.com/scanlime/fadecandy
-	DEPENDS:=+libpthread +librt +uclibcxx +libstdcpp +libc 
+	DEPENDS:=+libpthread +librt +uclibcxx +libstdcpp +libc +libusbx 
 endef
 
 define Package/fcserver/description


### PR DESCRIPTION
Needed to cross-compile using OSX 10.10
